### PR TITLE
Increasing json payload size limit for composite build

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,7 +3,7 @@ var app = express();
 var bodyParser = require('body-parser');
 //require('dotenv').config();
 
-app.use(bodyParser.json());
+app.use(bodyParser.json({limit: '5mb'}));
 //in latest body-parser use like below.
 app.use(bodyParser.urlencoded({ extended: true }));
 


### PR DESCRIPTION
I've been unsatisfied w/ the idea the composite build doesn't work so I said eff that and pulled this down to my machine and pointed the composite build at it and it yielded this:

```
PayloadTooLargeError: request entity too large
```

So I have bumped the size limit on json responses. It seemed to have done the trick while testing locally.

---

## PANCAKES

![giphy 10](https://user-images.githubusercontent.com/1141445/38224172-bf084278-36bc-11e8-9409-860dbf3820d7.gif)
